### PR TITLE
Journalist Can See Page of Articles Reviewed and Status

### DIFF
--- a/app/controllers/admin/dashboard_controller.rb
+++ b/app/controllers/admin/dashboard_controller.rb
@@ -2,6 +2,6 @@
 
 class Admin::DashboardController < Admin::AdminController
   def index
-    @articles = Article.approved
+    @articles = Article.where.not(status: 0)
   end
 end

--- a/app/controllers/admin/dashboard_controller.rb
+++ b/app/controllers/admin/dashboard_controller.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
 class Admin::DashboardController < Admin::AdminController
-  def index; end
+  def index
+    @articles = Article.approved
+  end
 end

--- a/app/controllers/admin/dashboard_controller.rb
+++ b/app/controllers/admin/dashboard_controller.rb
@@ -2,6 +2,6 @@
 
 class Admin::DashboardController < Admin::AdminController
   def index
-    @articles = Article.where.not(status: 0)
+    @articles = Article.where.not(status: :pending)
   end
 end

--- a/app/views/admin/dashboard/index.html.haml
+++ b/app/views/admin/dashboard/index.html.haml
@@ -3,3 +3,16 @@
         = link_to 'Create article', new_admin_article_path, class: "text-center block border border-blue rounded py-2 px-4 bg-blue hover:bg-blue-dark text-white"
     %li.mr-3
         = link_to 'Review articles', admin_articles_path, class: "text-center block border border-blue rounded py-2 px-4 bg-blue hover:bg-blue-dark text-white"
+
+%h2.mt-8.font-sans.font-thin Article Submission Portal - Reviewed Articles and Status
+.container.m-auto
+    - @articles.each do |article|
+        %div{id: dom_id(article)}
+            %h3.mt-8.font-sans.font-thin Header
+            %p.shadow.appearance-none.border.rounded.w-full.py-2.px-3.text-grey-darker.leading-tight.outline-none.shadow-outline= article.header
+            %h3.mt-8.font-sans.font-thin Subheader
+            %p.shadow.appearance-none.border.rounded.w-full.py-2.px-3.text-grey-darker.leading-tight.outline-none.shadow-outline= article.subheader
+            %h3.mt-8.font-sans.font-thin Body
+            %p.shadow.appearance-none.border.rounded.w-full.py-2.px-3.text-grey-darker.leading-tight.outline-none.shadow-outline= article.body
+            %h3.mt-8.font-sans.font-thin Status
+            %p.shadow.appearance-none.border.rounded.w-full.py-2.px-3.text-grey-darker.leading-tight.outline-none.shadow-outline= article.status.humanize

--- a/features/journalist_can_see_page_of_articles_reviewed_and_status.feature
+++ b/features/journalist_can_see_page_of_articles_reviewed_and_status.feature
@@ -19,10 +19,11 @@ Feature: Journalist can see reviewed articles
 
     Scenario: View list of reviewed articles
         When I visit the admin page
+        And stop
         Then I should see "Top title"
         And I should see "A breaking news item"
         And I should see "Today at craftacademy"
-        And I should see "Article approved and published"
+        And I should see "Approved"
         And I should not see "Other stories"
         And I should not see "Another breaking news"
         And I should not see "Tomorrow at craftacademy"

--- a/features/journalist_can_see_page_of_articles_reviewed_and_status.feature
+++ b/features/journalist_can_see_page_of_articles_reviewed_and_status.feature
@@ -1,0 +1,28 @@
+@javascript
+
+Feature: Journalist can see reviewed articles
+    As a Journalist,
+    In order to know if my article has been approved or if changes are needed,
+    I would like to be able to see a list of submitted articles by current status.
+
+    Background:
+        Given the following categories exist
+            | name        |
+            | Programming |
+            | Education   |
+
+        Given the following articles exist
+            | header        | subheader             | body                     | category    | status   |
+            | Top title     | A breaking news item  | Today at craftacademy    | Programming | approved |
+            | Other stories | Another breaking news | Tomorrow at craftacademy | Education   | pending  |
+
+
+    Scenario: View list of reviewed articles
+        When I visit the admin page
+        Then I should see "Top title"
+        And I should see "A breaking news item"
+        And I should see "Today at craftacademy"
+        And I should see "Article approved and published"
+        And I should not see "Other stories"
+        And I should not see "Another breaking news"
+        And I should not see "Tomorrow at craftacademy"

--- a/features/journalist_can_see_page_of_articles_reviewed_and_status.feature
+++ b/features/journalist_can_see_page_of_articles_reviewed_and_status.feature
@@ -12,9 +12,10 @@ Feature: Journalist can see reviewed articles
             | Education   |
 
         Given the following articles exist
-            | header        | subheader             | body                     | category    | status   |
-            | Top title     | A breaking news item  | Today at craftacademy    | Programming | approved |
-            | Other stories | Another breaking news | Tomorrow at craftacademy | Education   | pending  |
+            | header        | subheader             | body                      | category    | status   |
+            | Top title     | A breaking news item  | Today at craftacademy     | Programming | approved |
+            | Other stories | Another breaking news | Tomorrow at craftacademy  | Education   | pending  |
+            | More stories  | More breaking news    | Yesterday at craftacademy | Education   | rejected |
 
 
     Scenario: View list of reviewed articles
@@ -24,6 +25,9 @@ Feature: Journalist can see reviewed articles
         And I should see "A breaking news item"
         And I should see "Today at craftacademy"
         And I should see "Approved"
+        And I should see "More stories"
+        And I should see "Yesterday at craftacademy"
+        And I should see "Rejected"
         And I should not see "Other stories"
         And I should not see "Another breaking news"
         And I should not see "Tomorrow at craftacademy"

--- a/features/journalist_can_see_page_of_articles_reviewed_and_status.feature
+++ b/features/journalist_can_see_page_of_articles_reviewed_and_status.feature
@@ -20,7 +20,6 @@ Feature: Journalist can see reviewed articles
 
     Scenario: View list of reviewed articles
         When I visit the admin page
-        And stop
         Then I should see "Top title"
         And I should see "A breaking news item"
         And I should see "Today at craftacademy"


### PR DESCRIPTION
## PT Link

https://www.pivotaltracker.com/story/show/161365886

## Included in PR

* Add submitted articles list on dashboard view when logged in to account
* Add link to article creation/edit page for articles with comments
* Add ability to update article and resubmit for approval
* NOTE: Task - "Add ability to update article and resubmit for approval" has been moved to a separate PR due to size of task. Please see separate PR "Journalist can Edit and Resubmit Article Marked as For_Revision by Editor Review"

![image](https://user-images.githubusercontent.com/38586575/47300531-002aca00-d61d-11e8-9cb3-9811cb1667fd.png)
